### PR TITLE
Publish correct files in GitHub Releases triggered by workflows

### DIFF
--- a/.github/workflows/publish_project.yml
+++ b/.github/workflows/publish_project.yml
@@ -37,7 +37,10 @@ jobs:
       - name: Publish to GitHub
         uses: softprops/action-gh-release@v1
         with:
-          files: "build/libs/*.jar"
+          files: |
+            "build/libs/*.jar"
+            "build/libs/*.json"
+            "build/distributions/*.zip"
           generate_release_notes: true
           fail_on_unmatched_files: true
 


### PR DESCRIPTION
Releases should now include the Prism Launcher template instance ZIP file alongside the rest of lwjgl3ify's build artifacts.

Fixes #2