### PR TITLE
Fix key press events being counted twice

### DIFF
--- a/src/main/java/me/eigenraven/lwjgl3ify/mixins/early/game/MixinMinecraftKeyBinding.java
+++ b/src/main/java/me/eigenraven/lwjgl3ify/mixins/early/game/MixinMinecraftKeyBinding.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.Slice;
 public class MixinMinecraftKeyBinding {
 
     @Redirect(
-        method = "runTick",
+        method = "runTickKeyboard",
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/settings/KeyBinding;setKeyBindState(IZ)V"),
         slice = @Slice(from = @At(value = "INVOKE", target = "Lorg/lwjgl/input/Keyboard;next()Z", remap = false)))
     private void lwjgl3ify$noKeybindUpdateHere(int eventKey, boolean eventKeyState) {
@@ -22,7 +22,7 @@ public class MixinMinecraftKeyBinding {
     }
 
     @Redirect(
-        method = "runTick",
+        method = "runTickKeyboard",
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/settings/KeyBinding;onTick(I)V"),
         slice = @Slice(from = @At(value = "INVOKE", target = "Lorg/lwjgl/input/Keyboard;next()Z", remap = false)))
     private void lwjgl3ify$noKeybindTickHere(int eventKey) {


### PR DESCRIPTION
1.12 appears to do this processing in `runTickKeyboard`, not `runTick`.

Before this change, pressing F5 cycles through the perspectives twice, which results in the order of perspectives being backwards compared to what a vanilla player would expect.